### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ on a page client-side without a module loader:
 
 <!-- from npm -->
 <script src="node_modules/mainloop.js/build/mainloop.min.js"></script>
+
+<!-- via CDN -->
+<script src="https://cdn.jsdelivr.net/npm/mainloop.js@latest/build/mainloop.min.js"></script>
 ```
 
 You then have access to the `MainLoop` global.


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/mainloop.js) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.